### PR TITLE
Add blog post on Java 11, 17, 21 and 25 features

### DIFF
--- a/_posts/2026-03-03-java-11-17-21-features.md
+++ b/_posts/2026-03-03-java-11-17-21-features.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: Java 11, 17, 21 - The LTS Evolution
+---
+
+As the Java ecosystem continues to evolve with its six-month release cycle, the Long-Term Support (LTS) releases remain the bedrock for enterprise stability. Let's take a look at the major milestones from Java 11, 17, and the latest LTS, Java 21.
+
+## Java 11: Modernizing the Foundation
+
+Released in September 2018, Java 11 brought several developer-centric improvements:
+
+*   **HTTP Client (Standard)**: A new `HttpClient` API replaced the aging `HttpURLConnection`, supporting HTTP/2 and WebSockets natively.
+*   **Local-Variable Syntax for Lambda Parameters**: You can now use `var` in lambda expressions, allowing for annotations on lambda parameters.
+*   **Single-File Source-Code Programs**: Run Java files directly with `java HelloWorld.java` without explicit compilation.
+
+## Java 17: Refining the Language
+
+Java 17 (September 2021) focused on making the language more expressive and secure:
+
+*   **Sealed Classes**: Restrict which classes or interfaces may extend or implement them, providing better control over class hierarchies.
+*   **Records**: A concise way to create data-transfer objects (DTOs) with minimal boilerplate.
+*   **Pattern Matching for switch (Preview)**: Enhancing the `switch` statement to work with types and patterns.
+
+## Java 21: The Next Giant Leap
+
+Java 21 (September 2023) introduced groundbreaking features for scalability and data handling:
+
+*   **Virtual Threads (Project Loom)**: Lightweight threads that significantly reduce the overhead of concurrent applications, allowing for millions of active threads.
+*   **Sequenced Collections**: A new set of interfaces representing collections with a defined encounter order (e.g., `getFirst()`, `addLast()`).
+*   **Record Patterns**: Deconstruct record values to navigate data more easily using pattern matching.
+*   **String Templates (Preview)**: Simplified string composition with embedded expressions.
+
+The transition from Java 11 to 21 shows a clear path towards simpler syntax, better performance, and superior concurrency models. If you are still on Java 8 or 11, the features in 17 and 21 provide a compelling reason to upgrade!

--- a/_posts/2026-03-03-java-11-17-21-features.md
+++ b/_posts/2026-03-03-java-11-17-21-features.md
@@ -9,25 +9,82 @@ As the Java ecosystem continues to evolve with its six-month release cycle, the 
 
 Released in September 2018, Java 11 brought several developer-centric improvements:
 
-*   **HTTP Client (Standard)**: A new `HttpClient` API replaced the aging `HttpURLConnection`, supporting HTTP/2 and WebSockets natively.
-*   **Local-Variable Syntax for Lambda Parameters**: You can now use `var` in lambda expressions, allowing for annotations on lambda parameters.
-*   **Single-File Source-Code Programs**: Run Java files directly with `java HelloWorld.java` without explicit compilation.
+*   **HTTP Client (Standard)**: A new `HttpClient` API replaced the aging `HttpURLConnection`.
+    ```java
+    var client = HttpClient.newHttpClient();
+    var request = HttpRequest.newBuilder()
+        .uri(URI.create("https://api.example.com"))
+        .build();
+    client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+        .thenApply(HttpResponse::body)
+        .thenAccept(System.out::println);
+    ```
+*   **Local-Variable Syntax for Lambda Parameters**: You can now use `var` in lambda expressions.
+    ```java
+    List<String> list = List.of("a", "b", "c");
+    String result = list.stream()
+        .map((@Nonnull var s) -> s.toUpperCase())
+        .collect(Collectors.joining());
+    ```
+*   **Single-File Source-Code Programs**: Run Java files directly without explicit compilation.
+    ```bash
+    java HelloWorld.java
+    ```
 
 ## Java 17: Refining the Language
 
 Java 17 (September 2021) focused on making the language more expressive and secure:
 
-*   **Sealed Classes**: Restrict which classes or interfaces may extend or implement them, providing better control over class hierarchies.
-*   **Records**: A concise way to create data-transfer objects (DTOs) with minimal boilerplate.
-*   **Pattern Matching for switch (Preview)**: Enhancing the `switch` statement to work with types and patterns.
+*   **Sealed Classes**: Restrict which classes may extend or implement them.
+    ```java
+    public sealed interface Shape permits Circle, Square {}
+    public final class Circle implements Shape {}
+    public final class Square implements Shape {}
+    ```
+*   **Records**: A concise way to create data-transfer objects (DTOs).
+    ```java
+    public record Point(int x, int y) {}
+    ```
+*   **Pattern Matching for switch (Preview)**: Enhancing the `switch` statement to work with types.
+    ```java
+    static String formatter(Object obj) {
+        return switch (obj) {
+            case Integer i -> String.format("int %d", i);
+            case Long l    -> String.format("long %d", l);
+            case Double d  -> String.format("double %f", d);
+            case String s  -> String.format("String %s", s);
+            default        -> obj.toString();
+        };
+    }
+    ```
 
 ## Java 21: The Next Giant Leap
 
 Java 21 (September 2023) introduced groundbreaking features for scalability and data handling:
 
-*   **Virtual Threads (Project Loom)**: Lightweight threads that significantly reduce the overhead of concurrent applications, allowing for millions of active threads.
-*   **Sequenced Collections**: A new set of interfaces representing collections with a defined encounter order (e.g., `getFirst()`, `addLast()`).
-*   **Record Patterns**: Deconstruct record values to navigate data more easily using pattern matching.
-*   **String Templates (Preview)**: Simplified string composition with embedded expressions.
+*   **Virtual Threads (Project Loom)**: Lightweight threads for high-throughput concurrent applications.
+    ```java
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+        IntStream.range(0, 10_000).forEach(i -> {
+            executor.submit(() -> {
+                Thread.sleep(Duration.ofSeconds(1));
+                return i;
+            });
+        });
+    }
+    ```
+*   **Sequenced Collections**: New interfaces for collections with a defined encounter order.
+    ```java
+    LinkedHashSet<String> set = new LinkedHashSet<>();
+    set.addFirst("first");
+    set.addLast("last");
+    String first = set.getFirst();
+    ```
+*   **Record Patterns**: Deconstruct record values using pattern matching.
+    ```java
+    if (obj instanceof Point(int x, int y)) {
+        System.out.println("Coordinates: " + x + ", " + y);
+    }
+    ```
 
 The transition from Java 11 to 21 shows a clear path towards simpler syntax, better performance, and superior concurrency models. If you are still on Java 8 or 11, the features in 17 and 21 provide a compelling reason to upgrade!

--- a/_posts/2026-03-03-java-lts-evolution.md
+++ b/_posts/2026-03-03-java-lts-evolution.md
@@ -132,3 +132,11 @@ Released in September 2025, Java 25 continues the momentum of language moderniza
     ```
 
 The transition from Java 11 to 25 shows a clear path towards simpler syntax, better performance, and superior concurrency models. Each LTS version brings significant refinements that make Java a more powerful and enjoyable language to work with!
+
+## References
+
+*   [OpenJDK: JDK 25 JEPs integrated since JDK 21](https://openjdk.org/projects/jdk/25/jeps-since-jdk-21)
+*   [Oracle: JDK 25 Release Notes](https://www.oracle.com/java/technologies/javase/25all-relnotes.html)
+*   [Java Almanac: Java 25 Features](https://javaalmanac.io/jdk/25/)
+*   [Baeldung: String Templates in Java](https://www.baeldung.com/java-21-string-templates)
+*   [Advanced Web Machinery: Categorized List of Java Features (JDK 8 to 21)](https://advancedweb.hu/a-categorized-list-of-all-java-and-jvm-features-since-jdk-8-to-21/)

--- a/_posts/2026-03-03-java-lts-evolution.md
+++ b/_posts/2026-03-03-java-lts-evolution.md
@@ -3,13 +3,13 @@ layout: post
 title: Java 11, 17, 21, 25 - The LTS Evolution
 ---
 
-As the Java ecosystem continues to evolve with its six-month release cycle, the Long-Term Support (LTS) releases remain the bedrock for enterprise stability. Let's take a look at the major milestones from Java 11, 17, 21, and the newest LTS, Java 25.
+As the Java ecosystem continues to evolve with its six-month release cycle, the Long-Term Support (LTS) releases remain the bedrock for enterprise stability. Let's take a look at the major milestones from Java 11, 17, 21, and the newest LTS, Java 25, and understand the motivations behind these powerful features.
 
 ## Java 11: Modernizing the Foundation
 
 Released in September 2018, Java 11 brought several developer-centric improvements:
 
-*   **HTTP Client (Standard) [JEP 321]**: A new `HttpClient` API replaced the aging `HttpURLConnection`.
+*   **HTTP Client (Standard) [JEP 321]**: *What it solves:* Replaces the legacy, difficult-to-use `HttpURLConnection` with a modern, asynchronous API that supports HTTP/2 and WebSockets natively.
     ```java
     var client = HttpClient.newHttpClient();
     var request = HttpRequest.newBuilder()
@@ -19,14 +19,14 @@ Released in September 2018, Java 11 brought several developer-centric improvemen
         .thenApply(HttpResponse::body)
         .thenAccept(System.out::println);
     ```
-*   **Local-Variable Syntax for Lambda Parameters [JEP 323]**: You can now use `var` in lambda expressions.
+*   **Local-Variable Syntax for Lambda Parameters [JEP 323]**: *What it solves:* Enables the use of `var` in lambda expressions, primarily to allow for annotations (like `@Nonnull`) on lambda parameters, improving type safety and documentation.
     ```java
     List<String> list = List.of("a", "b", "c");
     String result = list.stream()
         .map((@Nonnull var s) -> s.toUpperCase())
         .collect(Collectors.joining());
     ```
-*   **Single-File Source-Code Programs [JEP 330]**: Run Java files directly without explicit compilation.
+*   **Single-File Source-Code Programs [JEP 330]**: *What it solves:* Reduces friction for beginners and small utility scripts by allowing them to run directly with the `java` command, eliminating the explicit `javac` compilation step.
     ```bash
     java HelloWorld.java
     ```
@@ -35,17 +35,17 @@ Released in September 2018, Java 11 brought several developer-centric improvemen
 
 Java 17 (September 2021) focused on making the language more expressive and secure:
 
-*   **Sealed Classes [JEP 409]**: Restrict which classes may extend or implement them.
+*   **Sealed Classes [JEP 409]**: *What it solves:* Provides a declarative way to restrict class hierarchies. It allows developers to specify exactly which classes may extend a given class, enhancing security and allowing for better domain modeling.
     ```java
     public sealed interface Shape permits Circle, Square {}
     public final class Circle implements Shape {}
     public final class Square implements Shape {}
     ```
-*   **Records [JEP 395]**: A concise way to create data-transfer objects (DTOs).
+*   **Records [JEP 395]**: *What it solves:* Eliminates the massive boilerplate required for "data-carrying" classes (DTOs). It automatically generates constructors, accessors, `equals`, `hashCode`, and `toString`.
     ```java
     public record Point(int x, int y) {}
     ```
-*   **Pattern Matching for switch (Preview) [JEP 406]**: Enhancing the `switch` statement to work with types.
+*   **Pattern Matching for switch (Preview) [JEP 406]**: *What it solves:* Reduces verbose and error-prone `instanceof` checks followed by explicit casting. It allows for a more concise and readable way to handle different types in a `switch` block.
     ```java
     static String formatter(Object obj) {
         return switch (obj) {
@@ -62,7 +62,7 @@ Java 17 (September 2021) focused on making the language more expressive and secu
 
 Java 21 (September 2023) introduced groundbreaking features for scalability and data handling:
 
-*   **Virtual Threads (Project Loom) [JEP 444]**: Lightweight threads for high-throughput concurrent applications.
+*   **Virtual Threads (Project Loom) [JEP 444]**: *What it solves:* Solves the scalability bottleneck of the "one thread per request" model. Virtual threads are lightweight and allow applications to handle millions of concurrent tasks with minimal resource overhead.
     ```java
     try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
         IntStream.range(0, 10_000).forEach(i -> {
@@ -73,20 +73,20 @@ Java 21 (September 2023) introduced groundbreaking features for scalability and 
         });
     }
     ```
-*   **Sequenced Collections [JEP 431]**: New interfaces for collections with a defined encounter order.
+*   **Sequenced Collections [JEP 431]**: *What it solves:* Standardizes access to the first and last elements of collections. Before this, developers had to use different, inconsistent APIs depending on whether they were using a `List`, `Deque`, or `SortedSet`.
     ```java
     LinkedHashSet<String> set = new LinkedHashSet<>();
     set.addFirst("first");
     set.addLast("last");
     String first = set.getFirst();
     ```
-*   **Record Patterns [JEP 440]**: Deconstruct record values using pattern matching.
+*   **Record Patterns [JEP 440]**: *What it solves:* Simplifies data extraction from records by allowing you to deconstruct record values directly within pattern matching logic.
     ```java
     if (obj instanceof Point(int x, int y)) {
         System.out.println("Coordinates: " + x + ", " + y);
     }
     ```
-*   **String Templates (Preview) [JEP 430]**: Introduced in Java 21 to simplify string composition. *Note: This feature was removed in JDK 23 pending a redesign and is not present in subsequent LTS versions in this form.*
+*   **String Templates (Preview) [JEP 430]**: *What it solves:* Aims to replace error-prone string concatenation and complex `String.format()` calls with a more secure and readable interpolation syntax. *Note: This feature was removed in JDK 23 pending a redesign.*
     ```java
     String name = "Java";
     String message = STR."Hello \{name}!";
@@ -96,7 +96,7 @@ Java 21 (September 2023) introduced groundbreaking features for scalability and 
 
 Released in September 2025, Java 25 continues the momentum of language modernization:
 
-*   **Flexible Constructor Bodies [JEP 513]**: You can now execute code *before* calling `super()` or `this()` in a constructor.
+*   **Flexible Constructor Bodies [JEP 513]**: *What it solves:* Allows developers to execute validation or initialization code *before* calling `super()` or `this()`. This removes a long-standing, rigid restriction in Java's constructor logic.
     ```java
     public class Customer extends Person {
         private final UUID id;
@@ -107,7 +107,7 @@ Released in September 2025, Java 25 continues the momentum of language moderniza
         }
     }
     ```
-*   **Module Import Declarations [JEP 511]**: Simplify your imports by importing an entire module's exported types.
+*   **Module Import Declarations [JEP 511]**: *What it solves:* Reduces the "import noise" in modular projects. It allows you to import all the exported types of a module with a single declaration, streamlining the development of large-scale modular applications.
     ```java
     import module java.base;
     import module com.company.utils;
@@ -119,12 +119,12 @@ Released in September 2025, Java 25 continues the momentum of language moderniza
         }
     }
     ```
-*   **Key Derivation Function API [JEP 510]**: A standard API for password-based key derivation (PBKDF2, scrypt).
+*   **Key Derivation Function API [JEP 510]**: *What it solves:* Provides a standard, high-level API for cryptographic key derivation. This prevents fragmented and potentially insecure custom implementations of algorithms like PBKDF2 and scrypt.
     ```java
     var kdf = KDF.getInstance("PBKDF2WithHmacSHA256");
     var key = kdf.deriveKey(...);
     ```
-*   **Primitive Types in Patterns (Preview) [JEP 507]**: Extend pattern matching to work seamlessly with all primitive types.
+*   **Primitive Types in Patterns (Preview) [JEP 507]**: *What it solves:* Enhances language consistency by extending the benefits of pattern matching (like deconstruction and type checking) to primitive types.
     ```java
     if (obj instanceof int i) {
         System.out.println("It's an int: " + i);

--- a/_posts/2026-03-03-java-lts-evolution.md
+++ b/_posts/2026-03-03-java-lts-evolution.md
@@ -86,7 +86,7 @@ Java 21 (September 2023) introduced groundbreaking features for scalability and 
         System.out.println("Coordinates: " + x + ", " + y);
     }
     ```
-*   **String Templates (Preview) [JEP 430]**: Simplified string composition with embedded expressions.
+*   **String Templates (Preview) [JEP 430]**: Introduced in Java 21 to simplify string composition. *Note: This feature was removed in JDK 23 pending a redesign and is not present in subsequent LTS versions in this form.*
     ```java
     String name = "Java";
     String message = STR."Hello \{name}!";

--- a/_posts/2026-03-03-java-lts-evolution.md
+++ b/_posts/2026-03-03-java-lts-evolution.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: Java 11, 17, 21 - The LTS Evolution
+title: Java 11, 17, 21, 25 - The LTS Evolution
 ---
 
-As the Java ecosystem continues to evolve with its six-month release cycle, the Long-Term Support (LTS) releases remain the bedrock for enterprise stability. Let's take a look at the major milestones from Java 11, 17, and the latest LTS, Java 21.
+As the Java ecosystem continues to evolve with its six-month release cycle, the Long-Term Support (LTS) releases remain the bedrock for enterprise stability. Let's take a look at the major milestones from Java 11, 17, 21, and the newest LTS, Java 25.
 
 ## Java 11: Modernizing the Foundation
 
@@ -87,4 +87,38 @@ Java 21 (September 2023) introduced groundbreaking features for scalability and 
     }
     ```
 
-The transition from Java 11 to 21 shows a clear path towards simpler syntax, better performance, and superior concurrency models. If you are still on Java 8 or 11, the features in 17 and 21 provide a compelling reason to upgrade!
+## Java 25: The First LTS of the Future
+
+Released in September 2025, Java 25 continues the momentum of language modernization:
+
+*   **Flexible Constructor Bodies**: You can now execute code *before* calling `super()` or `this()` in a constructor, making it easier to validate arguments or initialize fields.
+    ```java
+    public class Customer extends Person {
+        private final UUID id;
+        public Customer(String name) {
+            if (name == null || name.isBlank()) throw new IllegalArgumentException();
+            this.id = UUID.randomUUID();
+            super(name); // Now allowed after initialization/validation!
+        }
+    }
+    ```
+*   **Module Import Declarations**: Simplify your imports by importing an entire module's exported types with a single declaration.
+    ```java
+    import module java.base;
+    import module com.company.utils;
+
+    public class App {
+        public static void main(String[] args) {
+            List<String> list = List.of("Java 25"); // From java.base
+            Logger.info("Starting..."); // From com.company.utils
+        }
+    }
+    ```
+*   **Key Derivation Function API**: A standard API for password-based key derivation (PBKDF2, scrypt).
+    ```java
+    var kdf = KDF.getInstance("PBKDF2WithHmacSHA256");
+    var key = kdf.deriveKey(...);
+    ```
+*   **Primitive Types in Patterns (Preview)**: Extend pattern matching to work seamlessly with all primitive types.
+
+The transition from Java 11 to 25 shows a clear path towards simpler syntax, better performance, and superior concurrency models. Each LTS version brings significant refinements that make Java a more powerful and enjoyable language to work with!

--- a/_posts/2026-03-03-java-lts-evolution.md
+++ b/_posts/2026-03-03-java-lts-evolution.md
@@ -9,7 +9,7 @@ As the Java ecosystem continues to evolve with its six-month release cycle, the 
 
 Released in September 2018, Java 11 brought several developer-centric improvements:
 
-*   **HTTP Client (Standard)**: A new `HttpClient` API replaced the aging `HttpURLConnection`.
+*   **HTTP Client (Standard) [JEP 321]**: A new `HttpClient` API replaced the aging `HttpURLConnection`.
     ```java
     var client = HttpClient.newHttpClient();
     var request = HttpRequest.newBuilder()
@@ -19,14 +19,14 @@ Released in September 2018, Java 11 brought several developer-centric improvemen
         .thenApply(HttpResponse::body)
         .thenAccept(System.out::println);
     ```
-*   **Local-Variable Syntax for Lambda Parameters**: You can now use `var` in lambda expressions.
+*   **Local-Variable Syntax for Lambda Parameters [JEP 323]**: You can now use `var` in lambda expressions.
     ```java
     List<String> list = List.of("a", "b", "c");
     String result = list.stream()
         .map((@Nonnull var s) -> s.toUpperCase())
         .collect(Collectors.joining());
     ```
-*   **Single-File Source-Code Programs**: Run Java files directly without explicit compilation.
+*   **Single-File Source-Code Programs [JEP 330]**: Run Java files directly without explicit compilation.
     ```bash
     java HelloWorld.java
     ```
@@ -35,17 +35,17 @@ Released in September 2018, Java 11 brought several developer-centric improvemen
 
 Java 17 (September 2021) focused on making the language more expressive and secure:
 
-*   **Sealed Classes**: Restrict which classes may extend or implement them.
+*   **Sealed Classes [JEP 409]**: Restrict which classes may extend or implement them.
     ```java
     public sealed interface Shape permits Circle, Square {}
     public final class Circle implements Shape {}
     public final class Square implements Shape {}
     ```
-*   **Records**: A concise way to create data-transfer objects (DTOs).
+*   **Records [JEP 395]**: A concise way to create data-transfer objects (DTOs).
     ```java
     public record Point(int x, int y) {}
     ```
-*   **Pattern Matching for switch (Preview)**: Enhancing the `switch` statement to work with types.
+*   **Pattern Matching for switch (Preview) [JEP 406]**: Enhancing the `switch` statement to work with types.
     ```java
     static String formatter(Object obj) {
         return switch (obj) {
@@ -62,7 +62,7 @@ Java 17 (September 2021) focused on making the language more expressive and secu
 
 Java 21 (September 2023) introduced groundbreaking features for scalability and data handling:
 
-*   **Virtual Threads (Project Loom)**: Lightweight threads for high-throughput concurrent applications.
+*   **Virtual Threads (Project Loom) [JEP 444]**: Lightweight threads for high-throughput concurrent applications.
     ```java
     try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
         IntStream.range(0, 10_000).forEach(i -> {
@@ -73,25 +73,30 @@ Java 21 (September 2023) introduced groundbreaking features for scalability and 
         });
     }
     ```
-*   **Sequenced Collections**: New interfaces for collections with a defined encounter order.
+*   **Sequenced Collections [JEP 431]**: New interfaces for collections with a defined encounter order.
     ```java
     LinkedHashSet<String> set = new LinkedHashSet<>();
     set.addFirst("first");
     set.addLast("last");
     String first = set.getFirst();
     ```
-*   **Record Patterns**: Deconstruct record values using pattern matching.
+*   **Record Patterns [JEP 440]**: Deconstruct record values using pattern matching.
     ```java
     if (obj instanceof Point(int x, int y)) {
         System.out.println("Coordinates: " + x + ", " + y);
     }
+    ```
+*   **String Templates (Preview) [JEP 430]**: Simplified string composition with embedded expressions.
+    ```java
+    String name = "Java";
+    String message = STR."Hello \{name}!";
     ```
 
 ## Java 25: The First LTS of the Future
 
 Released in September 2025, Java 25 continues the momentum of language modernization:
 
-*   **Flexible Constructor Bodies**: You can now execute code *before* calling `super()` or `this()` in a constructor, making it easier to validate arguments or initialize fields.
+*   **Flexible Constructor Bodies [JEP 513]**: You can now execute code *before* calling `super()` or `this()` in a constructor.
     ```java
     public class Customer extends Person {
         private final UUID id;
@@ -102,7 +107,7 @@ Released in September 2025, Java 25 continues the momentum of language moderniza
         }
     }
     ```
-*   **Module Import Declarations**: Simplify your imports by importing an entire module's exported types with a single declaration.
+*   **Module Import Declarations [JEP 511]**: Simplify your imports by importing an entire module's exported types.
     ```java
     import module java.base;
     import module com.company.utils;
@@ -114,11 +119,16 @@ Released in September 2025, Java 25 continues the momentum of language moderniza
         }
     }
     ```
-*   **Key Derivation Function API**: A standard API for password-based key derivation (PBKDF2, scrypt).
+*   **Key Derivation Function API [JEP 510]**: A standard API for password-based key derivation (PBKDF2, scrypt).
     ```java
     var kdf = KDF.getInstance("PBKDF2WithHmacSHA256");
     var key = kdf.deriveKey(...);
     ```
-*   **Primitive Types in Patterns (Preview)**: Extend pattern matching to work seamlessly with all primitive types.
+*   **Primitive Types in Patterns (Preview) [JEP 507]**: Extend pattern matching to work seamlessly with all primitive types.
+    ```java
+    if (obj instanceof int i) {
+        System.out.println("It's an int: " + i);
+    }
+    ```
 
 The transition from Java 11 to 25 shows a clear path towards simpler syntax, better performance, and superior concurrency models. Each LTS version brings significant refinements that make Java a more powerful and enjoyable language to work with!


### PR DESCRIPTION
This PR adds a new blog post summarizing the key features introduced in Java LTS versions 11, 17, and 21. The post is located in the _posts/ directory and follows the standard Jekyll format used in the repository.

---
*PR created automatically by Jules for task [3207084748038108035](https://jules.google.com/task/3207084748038108035) started by @narendranss*