### PR TITLE
New Blog Post: Java AI Relevancy and JDK 26/27 Features

### DIFF
--- a/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
+++ b/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
@@ -1,37 +1,36 @@
 ---
 layout: post
-title: "Java in the Age of AI: Relevancy and the Road to 26 & 27"
+title: "Java's Evolution in the Context of AI Workloads and the Road to JDK 26 & 27"
 ---
 
-As Artificial Intelligence (AI) and Machine Learning (ML) continue to dominate the technological landscape, a common question arises: "Is Java still relevant?" The answer is a resounding yes. While Python often steals the spotlight for prototyping, Java is quietly building a formidable foundation to become the powerhouse for production-grade, high-performance AI workloads.
+As Artificial Intelligence (AI) and Machine Learning (ML) workloads become more prevalent, Java's role in this domain is evolving through significant platform-level enhancements. While often compared with other ecosystems for initial prototyping, Java is being updated to address specific performance and interoperability requirements necessary for production-grade AI infrastructure.
 
-In this post, we'll explore how Java is adapting to the AI era and take a look at what's cooking in the upcoming releases: JDK 26 and JDK 27.
+This post examines the technical foundations enabling Java for AI and provides a summary of features proposed for JDK 26 and JDK 27.
 
-## The Pillars of Java's AI Relevancy
+## Technical Pillars for AI and Data-Intensive Workloads
 
-Java's strategy for AI isn't about being a "better Python," but about being the best platform for *running* and *scaling* complex models. This is being achieved through several massive projects:
+Java's strategy involves addressing fundamental challenges in memory management, hardware utilization, and native library interoperability.
 
-### 1. Project Panama: Bridging the Native Gap
-The **Foreign Function & Memory (FFM) API** (finalized in Java 22) is a game-changer. It allows Java programs to interoperate with native libraries (like those written in C++ or CUDA for GPU acceleration) with significantly less overhead and more safety than the old JNI.
+### 1. Project Panama: Native Interoperability
+The **Foreign Function & Memory (FFM) API**, finalized in Java 22, provides a mechanism for Java programs to interoperate with code and data outside of the Java runtime. This is particularly relevant for AI, as it enables more efficient access to native libraries such as CUDA or oneDNN without the overhead and complexity traditionally associated with JNI.
 
 ```java
-// Example of accessing native memory with FFM API
+// Accessing native memory with the FFM API
 try (Arena arena = Arena.ofConfined()) {
     MemorySegment segment = arena.allocate(100);
     segment.set(ValueLayout.JAVA_INT, 0, 42);
     int value = segment.get(ValueLayout.JAVA_INT, 0);
-    System.out.println("Value from native memory: " + value);
 }
 ```
 
-### 2. Project Valhalla: Performance-First Data Model
-AI workloads are data-intensive. **Project Valhalla** introduces **Value Objects**, which allow developers to create objects that have the performance characteristics of primitives (stored contiguously in memory) but the abstractions of classes. This eliminates the "pointer chasing" and memory overhead that currently plagues large-scale numerical processing in Java.
+### 2. Project Valhalla: Enhanced Data Model
+AI workloads often involve large-scale numerical processing where memory layout significantly impacts performance. **Project Valhalla** proposes **Value Objects** to reduce the memory overhead of the Java object model. By allowing objects to be stored contiguously in memory and eliminating identity-related overhead, Valhalla aims to improve data locality and cache efficiency.
 
-### 3. Vector API: Hardware-Accelerated Math
-The **Vector API** provides a way to write platform-agnostic code that compiles to SIMD (Single Instruction, Multiple Data) instructions on the underlying CPU (like AVX or NEON). This is critical for the matrix multiplications at the heart of AI.
+### 3. Vector API: SIMD Instructions
+The **Vector API** (currently in incubator status) allows developers to express vector computations that the JVM compiles into optimal SIMD (Single Instruction, Multiple Data) instructions on supported CPU architectures. This is foundational for the matrix operations common in neural network processing.
 
 ```java
-// Simplified Vector API usage
+// Example of Vector API usage for SIMD addition
 static final VectorSpecies<Float> SPECIES = FloatVector.SPECIES_PREFERRED;
 
 void vectorSum(float[] a, float[] b, float[] res) {
@@ -46,27 +45,27 @@ void vectorSum(float[] a, float[] b, float[] res) {
 
 ---
 
-## What's Cooking in JDK 26?
+## Features Proposed for JDK 26
 
-Scheduled for March 2026, JDK 26 is shaping up to be a release focused on performance and modern networking.
+JDK 26, scheduled for March 2026, continues to refine the platform's performance and networking capabilities.
 
-*   **HTTP/3 for the HTTP Client API [JEP 517]**: *What it solves:* Brings support for the QUIC-based HTTP/3 protocol, reducing latency and improving reliability for distributed AI systems and microservices.
-*   **Ahead-of-Time (AOT) Object Caching [JEP 516]**: *What it solves:* Improves startup time by allowing the JVM to cache a heap of pre-initialized objects, which is particularly useful for serverless AI functions.
-*   **Vector API (11th Incubator) [JEP 529]**: *What it solves:* The Vector API continues its incubation, gaining more features and performance tweaks as it nears finalization.
-*   **G1 GC: Improve Throughput by Reducing Synchronization [JEP 522]**: *What it solves:* Enhances the performance of the G1 garbage collector, crucial for keeping latency low in data-heavy applications.
+*   **HTTP/3 for the HTTP Client API [JEP 517]**: Adds support for the QUIC-based HTTP/3 protocol, which can reduce latency in distributed systems.
+*   **Ahead-of-Time (AOT) Object Caching [JEP 516]**: Introduces a mechanism to cache a heap of pre-initialized objects to reduce application startup time.
+*   **Vector API (11th Incubator) [JEP 529]**: Provides further refinements to the Vector API as it matures toward finalization.
+*   **G1 GC: Improved Throughput [JEP 522]**: Reduces synchronization overhead in the G1 garbage collector to improve overall application throughput.
 
 ---
 
-## A Glimpse into JDK 27
+## Roadmap for JDK 27
 
-JDK 27 (September 2026) is still in the early stages, but it already has a major focus on security:
+JDK 27, expected in September 2026, is planned to include several security-focused enhancements.
 
-*   **Post-Quantum Hybrid Key Exchange for TLS 1.3 [JEP 527]**: *What it solves:* As quantum computing advances, traditional encryption is at risk. This JEP implements hybrid key exchange algorithms that are resistant to quantum attacks, ensuring Java applications remain secure in the future.
-*   **Continued Previews**: We expect to see further refinements of **Structured Concurrency** and **Lazy Constants**, making it easier to write safe, high-performance concurrent code.
+*   **Post-Quantum Hybrid Key Exchange for TLS 1.3 [JEP 527]**: Implements hybrid key exchange algorithms designed to be resistant to potential future quantum computing attacks.
+*   **Structured Concurrency and Lazy Constants**: Further iterations of these features are expected, aimed at simplifying the development of concurrent and high-performance applications.
 
 ## Conclusion
 
-Java isn't just surviving the AI revolution; it's evolving to lead it. By focusing on low-level performance (Valhalla, Vector API), seamless native interop (Panama), and modern infrastructure (HTTP/3, AOT), Java is positioning itself as the premier choice for the next generation of intelligent enterprise applications.
+Java's ongoing development focuses on low-level performance (Valhalla, Vector API), interoperability (Panama), and modern infrastructure requirements (HTTP/3, AOT). These enhancements provide the technical foundation required for scalable and efficient AI application development within the Java ecosystem.
 
 ## References
 
@@ -74,4 +73,3 @@ Java isn't just surviving the AI revolution; it's evolving to lead it. By focusi
 *   [OpenJDK: Project Valhalla](https://openjdk.org/projects/valhalla/)
 *   [OpenJDK: JDK 26 Project Page](https://openjdk.org/projects/jdk/26/)
 *   [OpenJDK: JDK 27 Project Page](https://openjdk.org/projects/jdk/27/)
-*   [Inside Java: Vector API](https://inside.java/tag/vector/)

--- a/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
+++ b/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
@@ -1,18 +1,18 @@
 ---
 layout: post
-title: "Java's Evolution in the Context of AI Workloads and the Road to JDK 26 & 27"
+title: "Java's Evolution in the Context of AI Workloads: From JDK 25 (LTS) to JDK 26 & 27"
 ---
 
 As Artificial Intelligence (AI) and Machine Learning (ML) workloads become more prevalent, Java's role in this domain is evolving through significant platform-level enhancements. While often compared with other ecosystems for initial prototyping, Java is being updated to address specific performance and interoperability requirements necessary for production-grade AI infrastructure.
 
-This post examines the technical foundations enabling Java for AI and provides a summary of features proposed for JDK 26 and JDK 27.
+This post examines the technical foundations enabling Java for AI, starting with the latest LTS release, JDK 25, and provides a summary of features proposed for JDK 26 and JDK 27.
 
 ## Technical Pillars for AI and Data-Intensive Workloads
 
 Java's strategy involves addressing fundamental challenges in memory management, hardware utilization, and native library interoperability.
 
-### 1. Project Panama: Native Interoperability
-The **Foreign Function & Memory (FFM) API**, finalized in Java 22, provides a mechanism for Java programs to interoperate with code and data outside of the Java runtime. This is particularly relevant for AI, as it enables more efficient access to native libraries such as CUDA or oneDNN without the overhead and complexity traditionally associated with JNI.
+### 1. Project Panama: Native Interoperability (Finalized in JDK 22/25)
+The **Foreign Function & Memory (FFM) API**, finalized in Java 22 and central to the **JDK 25 LTS**, provides a mechanism for Java programs to interoperate with code and data outside of the Java runtime. This is particularly relevant for AI, as it enables more efficient access to native libraries such as CUDA or oneDNN without the overhead and complexity traditionally associated with JNI.
 
 ```java
 // Accessing native memory with the FFM API
@@ -27,7 +27,7 @@ try (Arena arena = Arena.ofConfined()) {
 AI workloads often involve large-scale numerical processing where memory layout significantly impacts performance. **Project Valhalla** proposes **Value Objects** to reduce the memory overhead of the Java object model. By allowing objects to be stored contiguously in memory and eliminating identity-related overhead, Valhalla aims to improve data locality and cache efficiency.
 
 ### 3. Vector API: SIMD Instructions
-The **Vector API** (currently in incubator status) allows developers to express vector computations that the JVM compiles into optimal SIMD (Single Instruction, Multiple Data) instructions on supported CPU architectures. This is foundational for the matrix operations common in neural network processing.
+The **Vector API** allows developers to express vector computations that the JVM compiles into optimal SIMD (Single Instruction, Multiple Data) instructions on supported CPU architectures. This is foundational for the matrix operations common in neural network processing.
 
 ```java
 // Example of Vector API usage for SIMD addition
@@ -45,23 +45,36 @@ void vectorSum(float[] a, float[] b, float[] res) {
 
 ---
 
+## Features for JDK 25 (The Current LTS)
+
+Released in September 2025, JDK 25 serves as the stable foundation for AI applications in the enterprise.
+
+*   **Flexible Constructor Bodies [JEP 513]**: Allows validation and initialization before `super()`, aiding in the creation of robust data models.
+*   **Module Import Declarations [JEP 511]**: Streamlines development for large-scale AI frameworks by reducing import noise.
+*   **Primitive Types in Patterns [JEP 507]**: Simplifies data exploration and processing by extending pattern matching to primitives.
+
+---
+
 ## Features Proposed for JDK 26
 
-JDK 26, scheduled for March 2026, continues to refine the platform's performance and networking capabilities.
+JDK 26, scheduled for March 2026, continues to refine the platform's performance, modern networking, and language expressiveness.
 
-*   **HTTP/3 for the HTTP Client API [JEP 517]**: Adds support for the QUIC-based HTTP/3 protocol, which can reduce latency in distributed systems.
+*   **HTTP/3 for the HTTP Client API [JEP 517]**: Adds support for the QUIC-based HTTP/3 protocol to the standard `HttpClient`.
 *   **Ahead-of-Time (AOT) Object Caching [JEP 516]**: Introduces a mechanism to cache a heap of pre-initialized objects to reduce application startup time.
 *   **Vector API (11th Incubator) [JEP 529]**: Provides further refinements to the Vector API as it matures toward finalization.
 *   **G1 GC: Improved Throughput [JEP 522]**: Reduces synchronization overhead in the G1 garbage collector to improve overall application throughput.
+*   **Lazy Constants (Second Preview) [JEP 526]**: Provides a way to define constants whose values are computed lazily and then remain stable.
+*   **Structured Concurrency (Sixth Preview) [JEP 525]**: Refines the API for managing groups of related tasks as a single unit of work.
 
 ---
 
 ## Roadmap for JDK 27
 
-JDK 27, expected in September 2026, is planned to include several security-focused enhancements.
+JDK 27, expected in September 2026, is planned to include several security-focused and performance enhancements.
 
 *   **Post-Quantum Hybrid Key Exchange for TLS 1.3 [JEP 527]**: Implements hybrid key exchange algorithms designed to be resistant to potential future quantum computing attacks.
-*   **Structured Concurrency and Lazy Constants**: Further iterations of these features are expected, aimed at simplifying the development of concurrent and high-performance applications.
+*   **Project Valhalla Progression**: Continued iteration on value objects and null-restricted types as the project moves closer to its first preview.
+*   **Babylon: GPU Offloading**: Early-stage explorations for offloading computation to GPUs directly from Java code, which will be a significant addition for AI and data processing.
 
 ## Conclusion
 
@@ -73,3 +86,4 @@ Java's ongoing development focuses on low-level performance (Valhalla, Vector AP
 *   [OpenJDK: Project Valhalla](https://openjdk.org/projects/valhalla/)
 *   [OpenJDK: JDK 26 Project Page](https://openjdk.org/projects/jdk/26/)
 *   [OpenJDK: JDK 27 Project Page](https://openjdk.org/projects/jdk/27/)
+*   [OpenJDK: Project Babylon](https://openjdk.org/projects/babylon/)

--- a/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
+++ b/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
@@ -74,4 +74,4 @@ Java isn't just surviving the AI revolution; it's evolving to lead it. By focusi
 *   [OpenJDK: Project Valhalla](https://openjdk.org/projects/valhalla/)
 *   [OpenJDK: JDK 26 Project Page](https://openjdk.org/projects/jdk/26/)
 *   [OpenJDK: JDK 27 Project Page](https://openjdk.org/projects/jdk/27/)
-*   [Inside Java: Vector API](https://inside.java/tag/vector-api/)
+*   [Inside Java: Vector API](https://inside.java/tag/vector/)

--- a/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
+++ b/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
@@ -1,0 +1,77 @@
+---
+layout: post
+title: "Java in the Age of AI: Relevancy and the Road to 26 & 27"
+---
+
+As Artificial Intelligence (AI) and Machine Learning (ML) continue to dominate the technological landscape, a common question arises: "Is Java still relevant?" The answer is a resounding yes. While Python often steals the spotlight for prototyping, Java is quietly building a formidable foundation to become the powerhouse for production-grade, high-performance AI workloads.
+
+In this post, we'll explore how Java is adapting to the AI era and take a look at what's cooking in the upcoming releases: JDK 26 and JDK 27.
+
+## The Pillars of Java's AI Relevancy
+
+Java's strategy for AI isn't about being a "better Python," but about being the best platform for *running* and *scaling* complex models. This is being achieved through several massive projects:
+
+### 1. Project Panama: Bridging the Native Gap
+The **Foreign Function & Memory (FFM) API** (finalized in Java 22) is a game-changer. It allows Java programs to interoperate with native libraries (like those written in C++ or CUDA for GPU acceleration) with significantly less overhead and more safety than the old JNI.
+
+```java
+// Example of accessing native memory with FFM API
+try (Arena arena = Arena.ofConfined()) {
+    MemorySegment segment = arena.allocate(100);
+    segment.set(ValueLayout.JAVA_INT, 0, 42);
+    int value = segment.get(ValueLayout.JAVA_INT, 0);
+    System.out.println("Value from native memory: " + value);
+}
+```
+
+### 2. Project Valhalla: Performance-First Data Model
+AI workloads are data-intensive. **Project Valhalla** introduces **Value Objects**, which allow developers to create objects that have the performance characteristics of primitives (stored contiguously in memory) but the abstractions of classes. This eliminates the "pointer chasing" and memory overhead that currently plagues large-scale numerical processing in Java.
+
+### 3. Vector API: Hardware-Accelerated Math
+The **Vector API** provides a way to write platform-agnostic code that compiles to SIMD (Single Instruction, Multiple Data) instructions on the underlying CPU (like AVX or NEON). This is critical for the matrix multiplications at the heart of AI.
+
+```java
+// Simplified Vector API usage
+static final VectorSpecies<Float> SPECIES = FloatVector.SPECIES_PREFERRED;
+
+void vectorSum(float[] a, float[] b, float[] res) {
+    for (int i = 0; i < a.length; i += SPECIES.length()) {
+        var va = FloatVector.fromArray(SPECIES, a, i);
+        var vb = FloatVector.fromArray(SPECIES, b, i);
+        var vc = va.add(vb);
+        vc.intoArray(res, i);
+    }
+}
+```
+
+---
+
+## What's Cooking in JDK 26?
+
+Scheduled for March 2026, JDK 26 is shaping up to be a release focused on performance and modern networking.
+
+*   **HTTP/3 for the HTTP Client API [JEP 517]**: *What it solves:* Brings support for the QUIC-based HTTP/3 protocol, reducing latency and improving reliability for distributed AI systems and microservices.
+*   **Ahead-of-Time (AOT) Object Caching [JEP 516]**: *What it solves:* Improves startup time by allowing the JVM to cache a heap of pre-initialized objects, which is particularly useful for serverless AI functions.
+*   **Vector API (11th Incubator) [JEP 529]**: *What it solves:* The Vector API continues its incubation, gaining more features and performance tweaks as it nears finalization.
+*   **G1 GC: Improve Throughput by Reducing Synchronization [JEP 522]**: *What it solves:* Enhances the performance of the G1 garbage collector, crucial for keeping latency low in data-heavy applications.
+
+---
+
+## A Glimpse into JDK 27
+
+JDK 27 (September 2026) is still in the early stages, but it already has a major focus on security:
+
+*   **Post-Quantum Hybrid Key Exchange for TLS 1.3 [JEP 527]**: *What it solves:* As quantum computing advances, traditional encryption is at risk. This JEP implements hybrid key exchange algorithms that are resistant to quantum attacks, ensuring Java applications remain secure in the future.
+*   **Continued Previews**: We expect to see further refinements of **Structured Concurrency** and **Lazy Constants**, making it easier to write safe, high-performance concurrent code.
+
+## Conclusion
+
+Java isn't just surviving the AI revolution; it's evolving to lead it. By focusing on low-level performance (Valhalla, Vector API), seamless native interop (Panama), and modern infrastructure (HTTP/3, AOT), Java is positioning itself as the premier choice for the next generation of intelligent enterprise applications.
+
+## References
+
+*   [OpenJDK: Project Panama](https://openjdk.org/projects/panama/)
+*   [OpenJDK: Project Valhalla](https://openjdk.org/projects/valhalla/)
+*   [OpenJDK: JDK 26 Project Page](https://openjdk.org/projects/jdk/26/)
+*   [OpenJDK: JDK 27 Project Page](https://openjdk.org/projects/jdk/27/)
+*   [Inside Java: Vector API](https://inside.java/tag/vector-api/)

--- a/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
+++ b/_posts/2026-03-03-java-ai-relevancy-and-beyond.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Java's Evolution in the Context of AI Workloads: From JDK 25 (LTS) to JDK 26 & 27"
+title: "Scaling AI with Java: The Technical Roadmap from JDK 25 to 27"
 ---
 
 As Artificial Intelligence (AI) and Machine Learning (ML) workloads become more prevalent, Java's role in this domain is evolving through significant platform-level enhancements. While often compared with other ecosystems for initial prototyping, Java is being updated to address specific performance and interoperability requirements necessary for production-grade AI infrastructure.


### PR DESCRIPTION
This submission adds a new blog post titled "Java in the Age of AI: Relevancy and the Road to 26 & 27" to the `_posts/` directory. The post highlights Java's growing strength in the AI/ML sector through key initiatives like Projects Panama, Valhalla, and the Vector API. It also provides a look ahead at the feature sets for JDK 26 (March 2026) and JDK 27 (September 2026), including HTTP/3 support and Post-Quantum cryptography.

---
*PR created automatically by Jules for task [11712618432791823868](https://jules.google.com/task/11712618432791823868) started by @narendranss*