### PR TITLE
Remove obsolete Java 9 Moments and Kanban link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,9 +23,6 @@ version:          2.0.0
 github:           
   repo:           https://github.com/Wildcraft/
 
-projects:
-  first: https://github.com/orgs/Wildcraft/projects/1
-
 force-https: True
 
 google-tracking-id: "UA-105323889-1"

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,7 +26,6 @@
       {% endif %}
     {% endfor %}
     <a class="sidebar-nav-item" href="{{ site.github.repo }}">GitHub Repository</a>
-    <a class="sidebar-nav-item" href="{{ site.projects.first }}">Java 9 Exploration Kanban</a>
   </nav>
 
   <div class="sidebar-item">

--- a/java_9_moments.md
+++ b/java_9_moments.md
@@ -1,5 +1,0 @@
----
-layout: page
-title: Java 9 Moments
----
-<a class="twitter-moment" href="https://twitter.com/i/moments/949224401140047873?ref_src=twsrc%5Etfw">Java 9 Adoption</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 


### PR DESCRIPTION
The "Java 9 Moments" page and the "Java 9 Exploration Kanban" link were identified as obsolete and have been removed to clean up the website. This involved deleting the page file, removing the link from the sidebar, and cleaning up the configuration file.

---
*PR created automatically by Jules for task [505423049345807292](https://jules.google.com/task/505423049345807292) started by @narendranss*