### PR TITLE
Update Wildcraft Tech Radar for JDK 25-27

### DIFF
--- a/public/js/radar.data.js
+++ b/public/js/radar.data.js
@@ -35,11 +35,11 @@ radar_visualization({
       },
       {
         quadrant: 2,
-        ring: 1,
+        ring: 0,
         label: "Jigsaw",
         active: true,
-        link: "/public/js/data_processing/jigsaw.html",
-        moved: 0
+        link: "https://openjdk.org/projects/jigsaw/",
+        moved: 1
       },
       {
         quadrant: 2,
@@ -51,27 +51,27 @@ radar_visualization({
       },
       {
         quadrant: 2,
-        ring: 2,
+        ring: 0,
         label: "Amber",
         active: true,
-        link: "/public/js/data_processing/amber.html",
-        moved: 0
+        link: "https://openjdk.org/projects/amber/",
+        moved: 1
       },
       {
         quadrant: 2,
-        ring: 2,
+        ring: 0,
         label: "Loom",
         active: true,
-        link: "/public/js/data_processing/loom.html",
-        moved: 0
+        link: "https://openjdk.org/projects/loom/",
+        moved: 1
       },
       {
         quadrant: 2,
-        ring: 3,
+        ring: 0,
         label: "Panama",
         active: true,
-        link: "/public/js/data_processing/panama.html",
-        moved: 0
+        link: "https://openjdk.org/projects/panama/",
+        moved: 1
       },
       {
         quadrant: 2,
@@ -109,11 +109,11 @@ radar_visualization({
       //Concepts
       {
         quadrant: 3,
-        ring: 1,
+        ring: 0,
         label: "modularity",
         active: true,
-        link: "/public/js/data_processing/modularity.html",
-        moved: 0
+        link: "https://openjdk.org/projects/jigsaw/",
+        moved: 1
       },
       {
         quadrant: 3,
@@ -150,11 +150,51 @@ radar_visualization({
       },
       {
         quadrant: 1,
-        ring: 2,
+        ring: 0,
         label: "http",
         active: true,
-        link: "/public/js/data_processing/http.html",
+        link: "https://openjdk.org/jeps/321",
+        moved: 1
+      },
+      {
+        quadrant: 2,
+        ring: 1,
+        label: "Vector API",
+        active: true,
+        link: "https://openjdk.org/jeps/529",
+        moved: 1
+      },
+      {
+        quadrant: 1,
+        ring: 1,
+        label: "Structured Concurrency",
+        active: true,
+        link: "https://openjdk.org/jeps/525",
+        moved: 1
+      },
+      {
+        quadrant: 2,
+        ring: 2,
+        label: "Babylon",
+        active: true,
+        link: "https://openjdk.org/projects/babylon/",
         moved: 0
+      },
+      {
+        quadrant: 1,
+        ring: 2,
+        label: "HTTP/3",
+        active: true,
+        link: "https://openjdk.org/jeps/517",
+        moved: 0
+      },
+      {
+        quadrant: 0,
+        ring: 3,
+        label: "JNI",
+        active: true,
+        link: "https://docs.oracle.com/en/java/javase/23/docs/specs/jni/index.html",
+        moved: -1
       },
   ]
 


### PR DESCRIPTION
This PR updates the Wildcraft Tech Radar data to reflect the current status of key Java technologies in the JDK 25-27 era. Major stable features like Project Panama, Loom, and Amber have been moved to the ADOPT ring. New emerging technologies like Structured Concurrency, Vector API, and Project Babylon have been added to the TRIAL and ASSESS rings. Outdated technologies like JNI have been moved to HOLD. Existing relative links have been replaced with official OpenJDK Project and JEP URLs.

---
*PR created automatically by Jules for task [8830836678461885551](https://jules.google.com/task/8830836678461885551) started by @narendranss*